### PR TITLE
Update NonInviteServerTransactionStateTrying.java

### DIFF
--- a/peers-lib/src/main/java/net/sourceforge/peers/sip/transaction/NonInviteServerTransactionStateTrying.java
+++ b/peers-lib/src/main/java/net/sourceforge/peers/sip/transaction/NonInviteServerTransactionStateTrying.java
@@ -43,6 +43,7 @@ public class NonInviteServerTransactionStateTrying extends
         NonInviteServerTransactionState nextState =
             nonInviteServerTransaction.COMPLETED;
         nonInviteServerTransaction.setState(nextState);
+        nonInviteServerTransaction.sendLastResponse();
     }
     
 }


### PR DESCRIPTION
should add  nonInviteServerTransaction.sendLastResponse() into received200To699(), 
for example:
if UAS received non-invite request such as option. it should send 200 for option, if use your logic, the 200 can't be send due to it is trying state, and then the option will be retry after seconds, then your transaction state will be existed and be switched to completed state, it will send 200 after 2 options due to complete state will send 200 when received200To699.
it is same case for bye-200

so I think this is bug  we should fix.

paste the log：

[2015-07-30 17:04:02,073] - sip.transport.MessageReceiver.processMessage(MessageReceiver.java:88) [INFO ]  OPTIONS sip:3001@10.140.202.138:42312;transport=UDP SIP/2.0

=>[RECEIVED from] 10.224.2.213/5060
OPTIONS sip:3001@10.140.202.138:42312;transport=UDP SIP/2.0
Via: SIP/2.0/UDP 10.224.2.213:5060;branch=z9hG4bK31599de0;rport
From: "Unknown" sip:Unknown@10.224.2.213;tag=as5bc77a12
To: sip:3001@10.140.202.138:42312;transport=UDP
Contact: sip:Unknown@10.224.2.213
Call-ID: 2d3b837d06d765091aaab51e6104fd7c@10.224.2.213
CSeq: 102 OPTIONS
User-Agent: Asterisk PBX
Max-Forwards: 70
Date: Thu, 30 Jul 2015 23:10:20 GMT
Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, SUBSCRIBE, NOTIFY
Content-Length: 0

[2015-07-30 17:04:02,073] - sip.AbstractState.log(AbstractState.java:26) [INFO ]  SM z9hG4bK31599de0|OPTIONS [NonInviteServerTransactionStateTrying -> NonInviteServerTransactionStateCompleted] setState

[2015-07-30 17:04:03,118] - sip.transport.MessageReceiver.processMessage(MessageReceiver.java:88) [INFO ]  OPTIONS sip:3001@10.140.202.138:42312;transport=UDP SIP/2.0

=>[RECEIVED from] 10.224.2.213/5060
OPTIONS sip:3001@10.140.202.138:42312;transport=UDP SIP/2.0
Via: SIP/2.0/UDP 10.224.2.213:5060;branch=z9hG4bK31599de0;rport
From: "Unknown" sip:Unknown@10.224.2.213;tag=as5bc77a12
To: sip:3001@10.140.202.138:42312;transport=UDP
Contact: sip:Unknown@10.224.2.213
Call-ID: 2d3b837d06d765091aaab51e6104fd7c@10.224.2.213
CSeq: 102 OPTIONS
User-Agent: Asterisk PBX
Max-Forwards: 70
Date: Thu, 30 Jul 2015 23:10:20 GMT
Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, SUBSCRIBE, NOTIFY
Content-Length: 0

[2015-07-30 17:04:03,118] - sip.AbstractState.log(AbstractState.java:26) [INFO ]  SM z9hG4bK31599de0|OPTIONS [NonInviteServerTransactionStateCompleted -> NonInviteServerTransactionStateCompleted] setState
[2015-07-30 17:04:03,118] - sip.transport.UdpMessageSender.sendMessage(UdpMessageSender.java:69) [INFO ]  

=>[SENT] to 10.224.2.213/5060
SIP/2.0 200 OK
From: "Unknown" sip:Unknown@10.224.2.213;tag=as5bc77a12
Call-ID: 2d3b837d06d765091aaab51e6104fd7c@10.224.2.213
CSeq: 102 OPTIONS
Via: SIP/2.0/UDP 10.224.2.213:5060;rport=5060;branch=z9hG4bK31599de0
To: sip:3001@10.140.202.138:42312;transport=UDP;tag=TdfUyhH1lo
Content-Length: 331
Content-Type: application/sdp
Allow: INVITE, ACK, CANCEL, OPTIONS, BYE
Contact: sip:10.140.202.138:42312;transport=UDP

v=0
o=user1 533522953 1625389404 IN IP4 10.140.202.138
s=-
c=IN IP4 10.140.202.138
t=0 0
m=audio 59334 RTP/AVP 0 8 9 116 117 118 101
a=rtpmap:0 PCMU/8000
a=rtpmap:8 PCMA/8000
a=rtpmap:101 telephone-event/8000
a=sendrecv
