### PR TITLE
fix dtmf generator to be compatible with asterisk

### DIFF
--- a/peers-lib/src/main/java/net/sourceforge/peers/media/DtmfFactory.java
+++ b/peers-lib/src/main/java/net/sourceforge/peers/media/DtmfFactory.java
@@ -53,6 +53,7 @@ public class DtmfFactory {
         rtpPacket.setMarker(true);
         packets.add(rtpPacket);
 
+		/*
         // two classical packets
 
         rtpPacket = new RtpPacket();
@@ -74,20 +75,20 @@ public class DtmfFactory {
         rtpPacket.setMarker(false);
         rtpPacket.setPayloadType(RFC4733.PAYLOAD_TYPE_TELEPHONE_EVENT);
         packets.add(rtpPacket);
-
+		*/
         data = data.clone();
         // create three end event packets
         data[1] = -0x76; // end event flag + volume set to 10
         // set Duration to 640
         data[2] = 2; // duration 8 bits
         data[3] = -128; // duration 8 bits
-        for (int r = 0; r < 3; r++) {
+        //for (int r = 0; r < 1; r++) {
             rtpPacket = new RtpPacket();
             rtpPacket.setData(data);
             rtpPacket.setMarker(false);
             rtpPacket.setPayloadType(RFC4733.PAYLOAD_TYPE_TELEPHONE_EVENT);
             packets.add(rtpPacket);
-        }
+        //}
 
         return packets;
     }


### PR DESCRIPTION
sending serveral dtmf when pressing only one key make IVR not usable...

I had to remove that trick stuff in order to use peers successfully on by Asterisk platform

I suppose this implemented trick you did is usefull in other contexts.
Would be nice to be able to have the choice to enable or not that trick

