### PR TITLE
Paraplexed/rtp header strip

### DIFF
--- a/peers-lib/src/main/java/net/sourceforge/peers/rtp/RtpSession.java
+++ b/peers-lib/src/main/java/net/sourceforge/peers/rtp/RtpSession.java
@@ -234,15 +234,15 @@ public class RtpSession {
             int length = datagramPacket.getLength();
             byte[] trimmedData = new byte[length];
             System.arraycopy(data, offset, trimmedData, 0, length);
+            RtpPacket rtpPacket = rtpParser.decode(trimmedData);
             if (mediaDebug) {
                 try {
-                    rtpSessionInput.write(trimmedData);
+                    rtpSessionInput.write(rtpPacket.getData());
                 } catch (IOException e) {
                     logger.error("cannot write to file", e);
                     return;
                 }
             }
-            RtpPacket rtpPacket = rtpParser.decode(trimmedData);
             for (RtpListener rtpListener: rtpListeners) {
                 rtpListener.receivedRtpPacket(rtpPacket);
             }


### PR DESCRIPTION
The primary purpose here is that the mediaDebug setting should really only output the data from the RTP stream, not the headers. If the headers are left in and someone attempts to listen to the raw rtp_session.input file, there is a lot of static/popping. 

The main use case here for us is we are using the file that is generated from RtpSession, and comparing the audio to another audio file that we think that it should be. (call testing with audio comparisons)