### PR TITLE
upgraded to JDK 1.8

### DIFF
--- a/peers-demo/pom.xml
+++ b/peers-demo/pom.xml
@@ -9,6 +9,11 @@
   <url>http://maven.apache.org</url>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- set the java compiler version -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>
     <dependency>

--- a/peers-doc/pom.xml
+++ b/peers-doc/pom.xml
@@ -7,6 +7,14 @@
   <version>0.5.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- set the java compiler version -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
   <build>
     <plugins>
       <plugin>

--- a/peers-gui/pom.xml
+++ b/peers-gui/pom.xml
@@ -9,6 +9,10 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- set the java compiler version -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/peers-javaxsound/pom.xml
+++ b/peers-javaxsound/pom.xml
@@ -9,6 +9,10 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- set the java compiler version -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/peers-js/pom.xml
+++ b/peers-js/pom.xml
@@ -9,6 +9,11 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- set the java compiler version -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+
     <keystore>target/compstore</keystore>
     <storepass>123abc</storepass>
     <keypass>abc123</keypass>

--- a/peers-jws/pom.xml
+++ b/peers-jws/pom.xml
@@ -9,6 +9,11 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- set the java compiler version -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+
     <keystore>target/compstore</keystore>
     <storepass>123abc</storepass>
     <keypass>abc123</keypass>

--- a/peers-lib/pom.xml
+++ b/peers-lib/pom.xml
@@ -9,6 +9,10 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- set the java compiler version -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,10 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- set the java compiler version -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <modules>


### PR DESCRIPTION
first step to upgrade to JDK 17
Upgrade to latest orace/sun maintained version JDK8, since system dependency of peer-js to plugin.jar from oracle
see issue #52 for more details